### PR TITLE
Fix/no tomorrow

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -92,31 +92,6 @@ paths:
         '500':
           $ref: '#/components/responses/InternalServerError'
 
-  /api/{country}/tomorrow:
-    get:
-      tags:
-        - Countries
-      summary: Get tomorrow's energy prices
-      description: Get energy prices for a specific country from 00:00 to 23:59 of the next day
-      parameters:
-        - $ref: '#/components/parameters/CountryPath'
-        - $ref: '#/components/parameters/FixedMarkup'
-        - $ref: '#/components/parameters/VariableMarkup'
-        - $ref: '#/components/parameters/VAT'
-        - $ref: '#/components/parameters/AutoVAT'
-        - $ref: '#/components/parameters/RoundTo'
-      responses:
-        '200':
-          description: Tomorrow's energy prices
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/PricesResponse'
-        '400':
-          $ref: '#/components/responses/BadRequest'
-        '500':
-          $ref: '#/components/responses/InternalServerError'
-
   /api/{country}/next24h:
     get:
       tags:

--- a/readme.md
+++ b/readme.md
@@ -96,10 +96,10 @@ docker compose up -d
 curl http://localhost:3000/api/nl/today
 ```
 
-### Get tomorrow's prices with Next Energy markup
+### Get today's prices with Next Energy markup
 
 ```bash
-curl "http://localhost:3000/api/nl/tomorrow?markup=0.024&vat=0.21"
+curl "http://localhost:3000/api/nl/today?markup=0.024&vat=0.21"
 ```
 
 ### Get German prices with 'auto VAT'
@@ -122,7 +122,6 @@ curl http://localhost:3000/api/countries
 | ----------------------------- | ------------------------------- | ------------------ |
 | `GET /api/countries`          | List all supported countries    |                    |
 | `GET /api/{country}/today`    | Today's prices (00:00-23:59)    | `/api/nl/today`    |
-| `GET /api/{country}/tomorrow` | Tomorrow's prices (00:00-23:59) | `/api/de/tomorrow` |
 | `GET /api/{country}/next24h`  | Next 24 hours from now          | `/api/fr/next/24`  |
 
 ### 🇳🇱 Netherlands shortcuts 
@@ -130,7 +129,6 @@ curl http://localhost:3000/api/countries
 | Endpoint            | Description          | Equivalent To      |
 | ------------------- | -------------------- | ------------------ |
 | `GET /api/today`    | Netherlands today    | `/api/nl/today`    |
-| `GET /api/tomorrow` | Netherlands tomorrow | `/api/nl/tomorrow` |
 | `GET /api/next/24`  | Netherlands next 24h |                    |
 
 ### 🏢 Energy provider presets

--- a/routes/countries.js
+++ b/routes/countries.js
@@ -69,50 +69,6 @@ router.get('/:country/today', async (req, res) => {
   }
 });
 
-// Get tomorrow's prices for a specific country (00:00 - 23:59)
-router.get('/:country/tomorrow', async (req, res) => {
-  try {
-    const countryCode = validateCountry(req.params.country);
-    if (!countryCode) {
-      return res.status(400).json({
-        status: 'error',
-        message: `Unsupported country: ${req.params.country}. Use /api/countries to see supported countries.`
-      });
-    }
-
-    const country = COUNTRIES[countryCode];
-    const markupOptions = parseMarkupOptions(req.query, countryCode);
-
-    // Get tomorrow's start and end in country's timezone
-    const now = new Date();
-    const today = new Date(now.toLocaleString('en-US', { timeZone: country.timezone }));
-
-    const tomorrow = new Date(today);
-    tomorrow.setDate(tomorrow.getDate() + 1);
-
-    const tomorrowStart = new Date(tomorrow);
-    tomorrowStart.setHours(0, 0, 0, 0);
-
-    const tomorrowEnd = new Date(tomorrow);
-    tomorrowEnd.setHours(23, 59, 59, 999);
-
-    const prices = await fetchCountryPrices(countryCode, tomorrowStart, tomorrowEnd, false, markupOptions);
-    const enrichedPrices = enrichPricesWithCountryInfo(prices, countryCode);
-
-    const response = buildCountryResponse(countryCode, enrichedPrices, markupOptions, 'tomorrow', {
-      date: tomorrow.toLocaleDateString(country.locale, { timeZone: country.timezone })
-    });
-
-    res.json(response);
-  } catch (error) {
-    console.error(`Error fetching ${req.params.country} tomorrow prices:`, error);
-    res.status(500).json({
-      status: 'error',
-      message: error.message
-    });
-  }
-});
-
 // Get next 24 hours for a specific country
 router.get('/:country/next24h', async (req, res) => {
   try {

--- a/tests/api.test.js
+++ b/tests/api.test.js
@@ -65,15 +65,6 @@ describe('European Energy Prices API', () => {
       }
     }, 15000); // Extended timeout for API calls
 
-    test('GET /api/de/tomorrow should return German energy prices', async () => {
-      const response = await request(app).get('/api/de/tomorrow').expect(200);
-
-      expect(response.body).toHaveProperty('status', 'success');
-      expect(response.body).toHaveProperty('country');
-      expect(response.body.country).toHaveProperty('code', 'DE');
-      expect(response.body.country).toHaveProperty('currency', 'EUR');
-    }, 15000);
-
     test('GET /api/xx/today should return 400 for unsupported country', async () => {
       const response = await request(app).get('/api/xx/today').expect(400);
 


### PR DESCRIPTION
Tomorrow's endpoint only becomes available after 13hr CE(S)T.
And so let's remove it. We have today and next 24hrs available. That should suffice.